### PR TITLE
Changes to RStudio.RStudio.OpenSource for Publisher change

### DIFF
--- a/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.installer.yaml
+++ b/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.installer.yaml
@@ -11,6 +11,9 @@ InstallModes:
 FileExtensions:
 - r
 - rmd
+AppsAndFeaturesEntries:
+  - Publisher: RStudio
+    DisplayName: RStudio
 Installers:
 - InstallerLocale: en-US
   Architecture: x86

--- a/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.locale.en-US.yaml
+++ b/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.locale.en-US.yaml
@@ -17,6 +17,9 @@ Moniker: rstudio-opensource
 Tags:
 - rstats
 ReleaseNotesUrl: https://www.rstudio.com/products/rstudio/release-notes/
+Documentations:
+- DocumentLabel: User Guide
+  DocumentUrl: https://docs.posit.co/ide/user/
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0
 

--- a/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.locale.en-US.yaml
+++ b/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.locale.en-US.yaml
@@ -4,7 +4,7 @@
 PackageIdentifier: RStudio.RStudio.OpenSource
 PackageVersion: 2022.12.0+353
 PackageLocale: en-US
-Publisher: Posit Software, PBC
+Publisher: RStudio, PBC
 PublisherUrl: https://posit.co/
 PrivacyUrl: https://posit.co/about/privacy-policy/
 PackageName: RStudio Desktop Open Source Edition

--- a/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.locale.en-US.yaml
+++ b/manifests/r/RStudio/RStudio/OpenSource/2022.12.0+353/RStudio.RStudio.OpenSource.locale.en-US.yaml
@@ -16,6 +16,7 @@ Description: RStudio is an integrated development environment (IDE) for R. It in
 Moniker: rstudio-opensource
 Tags:
 - rstats
+ReleaseNotesUrl: https://www.rstudio.com/products/rstudio/release-notes/
 ManifestType: defaultLocale
 ManifestVersion: 1.2.0
 


### PR DESCRIPTION
A few changes to the exisiting RStudio.RStudio.OpenSource 2022.12.0+353 manifest to prepare for the Publisher Change