### PR TITLE
add Posit.RStudio.OpenSource version 2022.12.0+353 manifest

### DIFF
--- a/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.installer.yaml
+++ b/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json
+
+PackageIdentifier: Posit.RStudio.OpenSource
+PackageVersion: 2022.12.0+353
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+FileExtensions:
+- r
+- rmd
+AppsAndFeaturesEntries:
+  - Publisher: Posit Software
+    DisplayName: RStudio
+    ProductCode: RStudio
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerType: nullsoft
+  Scope: machine
+  InstallerUrl: https://download1.rstudio.org/electron/windows/RStudio-2022.12.0-353.exe
+  InstallerSha256: FD8EA4B45FD7382E628F01D7B55DCEE3765A51323AED459789BE7612798CCBE4
+  UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.2.0

--- a/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.locale.en-US.yaml
+++ b/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.locale.en-US.yaml
@@ -15,7 +15,7 @@ Description: RStudio is an integrated development environment (IDE) for R. It in
 Moniker: rstudio-opensource
 Tags:
 - rstats
-ReleaseNotesUrl: https://www.rstudio.com/products/rstudio/release-notes/
+ReleaseNotesUrl: https://docs.posit.co/ide/news/#rstudio-2022.12.0353
 Documentations:
 - DocumentLabel: User Guide
   DocumentUrl: https://docs.posit.co/ide/user/

--- a/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.locale.en-US.yaml
+++ b/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.2.0.schema.json
+
+PackageIdentifier: Posit.RStudio.OpenSource
+PackageVersion: 2022.12.0+353
+PackageLocale: en-US
+Publisher: Posit Software, PBC
+PublisherUrl: https://posit.co/
+PrivacyUrl: https://posit.co/about/privacy-policy/
+PackageName: RStudio Desktop Open Source Edition
+PackageUrl: https://posit.co/products/open-source/rstudio/
+License: GNU AFFERO GENERAL PUBLIC LICENSE
+LicenseUrl: https://github.com/rstudio/rstudio/blob/main/COPYING
+ShortDescription: RStudio is an integrated development environment (IDE) for R.
+Description: RStudio is an integrated development environment (IDE) for R. It includes a console, syntax-highlighting editor that supports direct code execution, as well as tools for plotting, history, debugging and workspace management.
+Moniker: rstudio-opensource
+Tags:
+- rstats
+ReleaseNotesUrl: https://www.rstudio.com/products/rstudio/release-notes/
+Documentations:
+- DocumentLabel: User Guide
+  DocumentUrl: https://docs.posit.co/ide/user/
+ManifestType: defaultLocale
+ManifestVersion: 1.2.0

--- a/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.yaml
+++ b/manifests/p/Posit/RStudio/OpenSource/2022.12.0+353/Posit.RStudio.OpenSource.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.2.0.schema.json
+
+PackageIdentifier: Posit.RStudio.OpenSource
+PackageVersion: 2022.12.0+353
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.2.0


### PR DESCRIPTION
Add new Posit.RStudio.OpenSource version 2022.12.0+353 manifest with Posit as Publisher.

@cderv, this is the new manifest with the necessary changes (AFAIU them from the [the corresponding FAQ entry](https://github.com/microsoft/winget-pkgs/blob/master/FAQ.md#what-should-i-do-if-a-package-is-being-published-by-a-new-publisher)). 

There are a few changes necessary to the existing manifest for that version, see #1. (And for reference, [your comment](https://github.com/microsoft/winget-pkgs/pull/91788#issuecomment-1358435593) on the original RStudio.RStudio.OpenSource version 2022.12.0+353 PR).

Feel free to copy the branch(es) and make changes as you like!